### PR TITLE
Fix android Ads SDK initialize error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,6 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.google.android.gms:play-services-ads:+'
+    compile 'com.google.android.gms:play-services-ads:16.0.0'
     compile 'com.facebook.react:react-native:+'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ptomasroos/react-native-idfa",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Android and iOS module to read IDFA",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
[Android update of the 5-th of October](https://developers.google.com/android/guides/releases#october_2nd_2018) has added a new ads lib version - com.google.android.gms:play-services-ads:17.0.0 that [requires com.google.android.gms.ads.APPLICATION_ID meta-tag](https://developers.google.com/admob/android/quick-start).

Notice:


_Important: This step is required as of Google Mobile Ads SDK version 17.0.0. Failure to add this <meta-data> tag results in a crash with the message: "The Google Mobile Ads SDK was initialized incorrectly."_


So either we need to add this meta-tag or downgrade and lock the version of the lib on 16.0.0