### PR TITLE
play-services-ads custom versions in rootProject

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,8 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def PLAY_SERVICES_ADS_VERSION = safeExtGet(playServicesAdsVersion, '15.0.1')
+
 buildscript {
     repositories {
         jcenter()
@@ -43,6 +45,6 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.google.android.gms:play-services-ads:+'
+    compile "com.google.android.gms:play-services-ads:$PLAY_SERVICES_ADS_VERSION"
     compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Updated to be able to set custom play-services-ads version in rootProject to avoid android dependencies resolution issue

