### PR TITLE
build.gradle: depend on play-services-ads-identifier instead of play-services-ads

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,6 @@ android {
 
 dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.google.android.gms:play-services-ads:+'
+    implementation 'com.google.android.gms:play-services-ads-identifier:+'
     implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
play-services-ads-identifier has less dependencies than play-services-ads (0 actually) and thus has a lower amount of friction of cooperating with other Play Services dependencies