### PR TITLE
Getting null IDFA

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ AdSupport in your IOS project.
 
 If you're using Cocoapods, there is no need to this as when you're adding react-native-idfa to your Podfile it will get added by default
 
+## iOS 14
+
+For iOS 14 and above App Tracking Transparency permission is a must for getting IDFA. If App Tracking Transparency permission is not granted on iOS 14 and above getIDFA() returns empty string.
+
 ## Podfile
 ```
   pod 'react-native-idfa',  path: '../node_modules/react-native-idfa'

--- a/ios/IDFA/PTRIDFA.m
+++ b/ios/IDFA/PTRIDFA.m
@@ -10,6 +10,7 @@
 #import <React/RCTUtils.h>
 #import <UIKit/UIKit.h>
 @import AdSupport;
+@import AppTrackingTransparency;
 
 @implementation PTRIDFA
 
@@ -23,11 +24,19 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(getIDFA:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    if([[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]) {
+    if([self isAdvertisingTrackingEnabled]) {
         NSUUID *IDFA = [[ASIdentifierManager sharedManager] advertisingIdentifier];
         resolve([IDFA UUIDString]);
     } else {
         resolve(@"");
+    }
+}
+
+- (BOOL) isAdvertisingTrackingEnabled {
+    if (@available(iOS 14, *)) {
+        return [ATTrackingManager trackingAuthorizationStatus] == ATTrackingManagerAuthorizationStatusAuthorized;
+    } else {
+        return [[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled];
     }
 }
 


### PR DESCRIPTION
This PR fixes getting null IDFA issue on iOS 14.
App Tracking Transparency is a must for iOS 14 and above otherwise getIDFA() will keep returning null.

Related issues:

Getting NULL IDFA #33 
Getting null when calling the idfa #47 