### PR TITLE
Edited for IOS 14.0.1 and later.

### DIFF
--- a/ios/IDFA/PTRIDFA.m
+++ b/ios/IDFA/PTRIDFA.m
@@ -33,10 +33,12 @@ RCT_EXPORT_METHOD(getIDFA:(RCTPromiseResolveBlock)resolve
 }
 
 - (BOOL) isAdvertisingTrackingEnabled {
-    if (@available(iOS 14, *)) {
-        return [ATTrackingManager trackingAuthorizationStatus] == ATTrackingManagerAuthorizationStatusAuthorized;
+    if (@available(iOS 14.0.1, *)) {
+      return true;
+    } else if (@available(iOS 14.0.0, *)) {
+      return [ATTrackingManager trackingAuthorizationStatus] == ATTrackingManagerAuthorizationStatusAuthorized;
     } else {
-        return [[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled];
+      return [[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled];
     }
 }
 


### PR DESCRIPTION
With the beta 7 version of iOS 14 which is iOS 14.0.1, the IDFA of a user will remain available by default and the IDFA only becomes unavailable when the user opts out of tracking. This PR implements iOS 14.0.1 control which means now you can get IDFA without ATT pop-up until early 2021.

Source: [https://www.adjust.com/blog/what-you-need-to-know-about-the-delay-to-ios-14-ad-tracking-changes//](url)